### PR TITLE
Add server orchestration CLI and recipe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,29 @@ pip install -r requirements.txt
 nano .env
 
 # 3. Start benchmark (example)
-python -m server run --recipe chroma-server
+python -m server run --recipe example-server
 python -m client run --recipe chroma-client
 python -m monitor run --output results/chroma.json
 
+```
+
+### Server CLI quick tour
+
+With the newly implemented server module you can explore the available recipes
+and deploy them via the CLI:
+
+```bash
+# Discover recipes stored under recipes/servers
+python -m server list
+
+# Inspect metadata about a specific recipe
+python -m server info --recipe example-server
+
+# Launch one or more instances using SLURM
+python -m server run --recipe example-server --count 2
+
+# Tear down running instances
+python -m server stop-all
 ```
 
 ## Setup

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -1,0 +1,6 @@
+# Example server workspace
+
+This directory is a placeholder for assets required by server recipes. The
+bundled `example-server` recipe starts Python's built-in HTTP server from this
+location, but you can swap in your own startup scripts or binaries depending on
+the workload you want to benchmark.

--- a/recipes/servers/example-server.yaml
+++ b/recipes/servers/example-server.yaml
@@ -1,0 +1,13 @@
+name: example-server
+description: Example HTTP server served via Python's built-in module
+service:
+  command: python -m http.server 8000
+  working_dir: ./examples/server
+  env:
+    LOG_LEVEL: info
+  ports:
+    - 8000
+orchestration:
+  resources:
+    cpu_cores: 1
+    memory_gb: 2

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for `python -m server` invocations."""
+
+from src.server import *  # noqa: F401,F403

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,0 +1,7 @@
+"""Entry-point shim for `python -m server`."""
+
+from src.server.__main__ import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,16 @@
+"""Server module public API."""
+
+from .manager import ServerManager
+from .recipe_loader import ServerRecipeLoader
+from .recipe import ServerRecipe
+from .server_instance import ServerInstance, ServerStatus
+from .orchestrator import ServerOrchestrator
+
+__all__ = [
+    "ServerManager",
+    "ServerRecipeLoader",
+    "ServerRecipe",
+    "ServerInstance",
+    "ServerStatus",
+    "ServerOrchestrator",
+]

--- a/src/server/__main__.py
+++ b/src/server/__main__.py
@@ -1,0 +1,119 @@
+"""Command line interface for server deployments."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .manager import ServerManager
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Server deployment CLI",
+        prog="python -m server",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    run_parser = subparsers.add_parser("run", help="Deploy a server from a recipe")
+    run_parser.add_argument("--recipe", required=True, help="Recipe name to deploy")
+    run_parser.add_argument("--count", type=int, default=1, help="Number of instances to launch")
+
+    subparsers.add_parser("list", help="List available server recipes")
+
+    stop_parser = subparsers.add_parser("stop", help="Stop a running server instance")
+    stop_parser.add_argument("--name", required=True, help="Instance name to stop")
+
+    subparsers.add_parser("stop-all", help="Stop every tracked server instance")
+
+    subparsers.add_parser("status", help="Show status for tracked server instances")
+
+    info_parser = subparsers.add_parser("info", help="Show information about a recipe")
+    info_parser.add_argument("--recipe", required=True, help="Recipe name")
+
+    template_parser = subparsers.add_parser("template", help="Create a recipe template")
+    template_parser.add_argument("--name", required=True, help="Template file name")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    manager = ServerManager()
+
+    if args.command == "run":
+        try:
+            deployments = manager.run(args.recipe, count=args.count)
+        except Exception as exc:  # pragma: no cover - CLI guard
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Submitted {len(deployments)} instance(s)")
+        for instance in deployments:
+            print(f"  - {instance.recipe_name}:{instance.id[:8]} -> {instance.orchestrator_handle}")
+
+    elif args.command == "list":
+        recipes = manager.list_available_recipes()
+        if not recipes:
+            print("No recipes found")
+        else:
+            print("Available recipes:")
+            for name in recipes:
+                print(f"  - {name}")
+
+    elif args.command == "stop":
+        if manager.stop(args.name):
+            print(f"Stopped instance: {args.name}")
+        else:
+            print(f"Instance not found or could not be stopped: {args.name}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == "stop-all":
+        stopped = manager.stop_all()
+        print(f"Stopped {len(stopped)} instance(s)")
+        for name in stopped:
+            print(f"  - {name}")
+
+    elif args.command == "status":
+        statuses = manager.collect_status()
+        if not statuses:
+            print("No tracked instances")
+        else:
+            print("Tracked instances:")
+            for info in statuses:
+                print(f"  - {info['name']}")
+                print(f"      Status: {info['status']}")
+                print(f"      Uptime: {info['uptime_seconds']:.1f}s")
+                if info.get("ports"):
+                    print(f"      Ports:  {', '.join(str(p) for p in info['ports'])}")
+
+    elif args.command == "info":
+        info = manager.info(args.recipe)
+        if not info:
+            print(f"Recipe not found: {args.recipe}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Recipe:       {info['name']}")
+        print(f"Description:  {info['description']}")
+        print(f"Command:      {info['command']}")
+        print(f"Location:     {info['file_path']}")
+
+    elif args.command == "template":
+        try:
+            destination = manager.recipe_loader.create_recipe_template(args.name)
+        except Exception as exc:  # pragma: no cover - CLI guard
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Template created at {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/manager.py
+++ b/src/server/manager.py
@@ -1,0 +1,102 @@
+"""High-level orchestration for server deployments."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .recipe_loader import ServerRecipeLoader
+from .server_instance import ServerInstance
+from .orchestrator import ServerOrchestrator
+
+
+class ServerManager:
+    """Coordinates recipe management and SLURM submissions for servers."""
+
+    def __init__(self, recipe_directory: str = "recipes/servers") -> None:
+        self.recipe_loader = ServerRecipeLoader(recipe_directory=recipe_directory)
+        self.instances: Dict[str, ServerInstance] = {}
+        self._orchestrator: ServerOrchestrator | None = None
+
+    # ------------------------------------------------------------------
+    @property
+    def orchestrator(self) -> ServerOrchestrator:
+        if self._orchestrator is None:
+            self._orchestrator = ServerOrchestrator()
+        return self._orchestrator
+
+    # ------------------------------------------------------------------
+    def run(self, recipe_name: str, *, count: int = 1) -> List[ServerInstance]:
+        recipe = self.recipe_loader.load_recipe(recipe_name)
+
+        deployments: List[ServerInstance] = []
+        for index in range(count):
+            instance = ServerInstance(
+                recipe_name=recipe.name,
+                orchestrator_handle=f"pending-{index}",
+                command=recipe.service.get("command", ""),
+                ports=recipe.ports,
+            )
+
+            try:
+                job_id = self.orchestrator.submit(instance, recipe)
+            except Exception as exc:
+                instance.mark_failed()
+                raise RuntimeError(f"Failed to submit server job: {exc}") from exc
+
+            instance.orchestrator_handle = job_id
+            instance.mark_starting()
+
+            name = f"{recipe.name}-{instance.id[:8]}"
+            self.instances[name] = instance
+            deployments.append(instance)
+
+        return deployments
+
+    # ------------------------------------------------------------------
+    def stop(self, name: str) -> bool:
+        instance = self.instances.get(name)
+        if not instance:
+            return False
+
+        if self.orchestrator.stop(instance.orchestrator_handle):
+            instance.cancel()
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    def stop_all(self) -> List[str]:
+        stopped: List[str] = []
+        for name in list(self.instances.keys()):
+            if self.stop(name):
+                stopped.append(name)
+        return stopped
+
+    # ------------------------------------------------------------------
+    def collect_status(self) -> List[Dict[str, str]]:
+        status_list: List[Dict[str, str]] = []
+        for name, instance in self.instances.items():
+            try:
+                status = self.orchestrator.status(instance.orchestrator_handle)
+                instance.update_status(status)
+            except Exception:
+                # Failure to query SLURM should not break status collection.
+                pass
+
+            status_list.append({
+                "name": name,
+                **instance.get_metrics(),
+            })
+
+        return status_list
+
+    # ------------------------------------------------------------------
+    def list_available_recipes(self) -> List[str]:
+        return self.recipe_loader.list_available_recipes()
+
+    # ------------------------------------------------------------------
+    def info(self, recipe_name: str) -> Dict[str, str]:
+        return self.recipe_loader.get_recipe_info(recipe_name)
+
+
+__all__ = ["ServerManager"]

--- a/src/server/orchestrator.py
+++ b/src/server/orchestrator.py
@@ -1,0 +1,174 @@
+"""SLURM orchestrator for server deployments."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+from dotenv import load_dotenv
+
+from .server_instance import ServerStatus
+
+
+class ServerOrchestrator:
+    """Wraps SLURM commands used to manage server jobs."""
+
+    def __init__(
+        self,
+        *,
+        partition: str | None = None,
+        account: str | None = None,
+        qos: str | None = None,
+        time_limit: str | None = None,
+    ) -> None:
+        load_dotenv()
+
+        self.account = account or os.getenv("SLURM_ACCOUNT")
+        self.partition = partition or os.getenv("SLURM_PARTITION", "cpu")
+        self.qos = qos or os.getenv("SLURM_QOS", "default")
+        self.time_limit = time_limit or os.getenv("SLURM_TIME_LIMIT", "04:00:00")
+
+        if not self.account:
+            raise ValueError("SLURM account must be provided (set SLURM_ACCOUNT or pass account=)")
+
+    # ------------------------------------------------------------------
+    def submit(self, instance, recipe) -> str:
+        script_content = self._build_batch_script(instance, recipe)
+        return self._submit_job(script_content)
+
+    # ------------------------------------------------------------------
+    def stop(self, job_id: str) -> bool:
+        try:
+            subprocess.run(
+                ["scancel", job_id],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    # ------------------------------------------------------------------
+    def status(self, job_id: str) -> ServerStatus:
+        try:
+            result = subprocess.run(
+                ["squeue", "-j", job_id, "--format=%T", "--noheader"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return ServerStatus.COMPLETED
+
+        status_map: Dict[str, ServerStatus] = {
+            "PENDING": ServerStatus.SUBMITTED,
+            "CONFIGURING": ServerStatus.STARTING,
+            "RUNNING": ServerStatus.RUNNING,
+            "COMPLETED": ServerStatus.COMPLETED,
+            "COMPLETING": ServerStatus.COMPLETED,
+            "FAILED": ServerStatus.FAILED,
+            "TIMEOUT": ServerStatus.FAILED,
+            "CANCELLED": ServerStatus.CANCELED,
+        }
+
+        slurm_status = result.stdout.strip().splitlines()
+        if not slurm_status:
+            return ServerStatus.COMPLETED
+
+        return status_map.get(slurm_status[0], ServerStatus.RUNNING)
+
+    # ------------------------------------------------------------------
+    def _build_batch_script(self, instance, recipe) -> str:
+        resources = recipe.resources
+        cpu_cores = resources.get("cpu_cores", 1)
+        memory_gb = resources.get("memory_gb", 4)
+
+        working_dir = recipe.working_directory or os.getcwd()
+        working_path = Path(working_dir)
+        if not working_path.is_absolute():
+            working_path = Path(os.getcwd()) / working_path
+
+        env_exports = "\n".join(
+            f'export {key}="{value}"'
+            for key, value in recipe.env.items()
+        )
+
+        if env_exports:
+            env_exports += "\n"
+
+        port_info = " ".join(str(p) for p in recipe.ports)
+
+        script = f"""#!/bin/bash -l
+
+#SBATCH --job-name={recipe.name}_{instance.id[:8]}
+#SBATCH --time={self.time_limit}
+#SBATCH --qos={self.qos}
+#SBATCH --partition={self.partition}
+#SBATCH --account={self.account}
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task={cpu_cores}
+#SBATCH --mem={memory_gb}G
+
+echo "========================================="
+echo "Server Deployment"
+echo "========================================="
+echo "Date              = $(date)"
+echo "Hostname          = $(hostname -s)"
+echo "Working Directory = {working_path}"
+echo "Job ID            = $SLURM_JOB_ID"
+echo "Instance ID       = {instance.id}"
+echo "Recipe            = {recipe.name}"
+echo "Command           = {recipe.service.get('command', '')}"
+echo "Ports             = {port_info}"
+echo "========================================="
+
+cd {working_path}
+
+{env_exports}{recipe.service.get('command')}
+
+EXIT_CODE=$?
+
+echo ""
+echo "========================================="
+echo "Service exited with code $EXIT_CODE"
+echo "========================================="
+
+exit $EXIT_CODE
+"""
+        return script
+
+    # ------------------------------------------------------------------
+    def _submit_job(self, script_content: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as handle:
+            handle.write(script_content)
+            script_path = handle.name
+
+        try:
+            result = subprocess.run(
+                ["sbatch", script_path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.strip() if exc.stderr else ""
+            raise RuntimeError(f"Job submission failed: {stderr}") from exc
+        finally:
+            try:
+                os.unlink(script_path)
+            except OSError:
+                pass
+
+        output = result.stdout.strip().split()
+        if not output:
+            raise RuntimeError("Unexpected empty response from sbatch")
+
+        return output[-1]
+
+
+__all__ = ["ServerOrchestrator"]

--- a/src/server/recipe.py
+++ b/src/server/recipe.py
@@ -1,0 +1,81 @@
+"""Recipe definition for server deployments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+class ServerRecipe:
+    """Represents a server deployment recipe loaded from YAML."""
+
+    def __init__(
+        self,
+        name: str,
+        service: Dict[str, Any],
+        *,
+        orchestration: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.service = service or {}
+        self.orchestration = orchestration or {}
+        self.description = description
+
+    # ------------------------------------------------------------------
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("Recipe name is required")
+
+        if not self.service:
+            raise ValueError("service definition is required")
+
+        command = self.service.get("command")
+        if not command or not isinstance(command, str):
+            raise ValueError("service.command must be a non-empty string")
+
+        ports = self.service.get("ports", [])
+        if any(p <= 0 or p > 65535 for p in ports):
+            raise ValueError("service.ports must contain valid TCP port numbers")
+
+    # ------------------------------------------------------------------
+    @property
+    def resources(self) -> Dict[str, Any]:
+        return self.orchestration.get("resources", {})
+
+    @property
+    def env(self) -> Dict[str, str]:
+        return self.service.get("env", {})
+
+    @property
+    def working_directory(self) -> Optional[str]:
+        return self.service.get("working_dir")
+
+    @property
+    def ports(self) -> list[int]:
+        return list(self.service.get("ports", []))
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_yaml(cls, yaml_path: str) -> "ServerRecipe":
+        path = Path(yaml_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Recipe file not found: {yaml_path}")
+
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+
+        recipe = cls(
+            name=data.get("name"),
+            service=data.get("service", {}),
+            orchestration=data.get("orchestration"),
+            description=data.get("description"),
+        )
+
+        recipe.validate()
+        return recipe
+
+
+__all__ = ["ServerRecipe"]

--- a/src/server/recipe_loader.py
+++ b/src/server/recipe_loader.py
@@ -1,0 +1,98 @@
+"""Utilities for discovering and validating server recipes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+from .recipe import ServerRecipe
+
+
+class ServerRecipeLoader:
+    """Loads server recipes from a directory on disk."""
+
+    def __init__(self, recipe_directory: str = "recipes/servers") -> None:
+        self.recipe_directory = Path(recipe_directory)
+        self.recipe_directory.mkdir(parents=True, exist_ok=True)
+        self._cache: Dict[str, ServerRecipe] = {}
+
+    # ------------------------------------------------------------------
+    def load_recipe(self, name: str) -> ServerRecipe:
+        if name in self._cache:
+            return self._cache[name]
+
+        recipe_path = self._find_recipe_file(name)
+        if not recipe_path:
+            raise FileNotFoundError(f"Recipe not found: {name}")
+
+        recipe = ServerRecipe.from_yaml(str(recipe_path))
+        self._cache[name] = recipe
+        return recipe
+
+    # ------------------------------------------------------------------
+    def list_available_recipes(self) -> List[str]:
+        recipes: List[str] = []
+        for pattern in ("*.yml", "*.yaml"):
+            recipes.extend(sorted(f.stem for f in self.recipe_directory.glob(pattern)))
+        return sorted(set(recipes))
+
+    # ------------------------------------------------------------------
+    def get_recipe_info(self, name: str) -> Dict[str, str]:
+        recipe_path = self._find_recipe_file(name)
+        if not recipe_path:
+            return {}
+
+        with open(recipe_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+
+        return {
+            "name": data.get("name", name),
+            "description": data.get("description", "No description"),
+            "file_path": str(recipe_path),
+            "command": data.get("service", {}).get("command", "unknown"),
+        }
+
+    # ------------------------------------------------------------------
+    def create_recipe_template(self, name: str) -> Path:
+        """Create a new recipe file populated with a starter template."""
+
+        destination = self.recipe_directory / f"{name}.yaml"
+        if destination.exists():
+            raise FileExistsError(f"Recipe already exists: {destination}")
+
+        template = {
+            "name": name,
+            "description": "Describe the service this recipe deploys.",
+            "service": {
+                "command": "python -m http.server 8000",
+                "working_dir": "./",
+                "env": {
+                    "EXAMPLE_ENV": "value",
+                },
+                "ports": [8000],
+            },
+            "orchestration": {
+                "resources": {
+                    "cpu_cores": 2,
+                    "memory_gb": 4,
+                }
+            },
+        }
+
+        with open(destination, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(template, handle, sort_keys=False)
+
+        return destination
+
+    # ------------------------------------------------------------------
+    def _find_recipe_file(self, name: str) -> Optional[Path]:
+        for ext in (".yml", ".yaml"):
+            candidate = self.recipe_directory / f"{name}{ext}"
+            if candidate.exists():
+                return candidate
+        return None
+
+
+__all__ = ["ServerRecipeLoader"]

--- a/src/server/server_instance.py
+++ b/src/server/server_instance.py
@@ -1,0 +1,97 @@
+"""Runtime representation for deployed server instances."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class ServerStatus(Enum):
+    """Lifecycle states for a server deployment."""
+
+    SUBMITTED = "submitted"
+    STARTING = "starting"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+class ServerInstance:
+    """Represents a single server deployment managed via SLURM."""
+
+    def __init__(
+        self,
+        recipe_name: str,
+        orchestrator_handle: str,
+        command: str,
+        *,
+        ports: Optional[list[int]] = None,
+    ) -> None:
+        self.id = str(uuid.uuid4())
+        self.recipe_name = recipe_name
+        self.command = command
+        self.orchestrator_handle = orchestrator_handle
+        self.status = ServerStatus.SUBMITTED
+        self.ports = ports or []
+        self.created_at = datetime.now()
+        self.completed_at: Optional[datetime] = None
+        self.metadata: Dict[str, Any] = {}
+
+    # ---------------------------------------------------------------------
+    # Lifecycle helpers
+    # ---------------------------------------------------------------------
+    def mark_starting(self) -> None:
+        self.update_status(ServerStatus.STARTING)
+
+    def mark_running(self) -> None:
+        self.update_status(ServerStatus.RUNNING)
+
+    def mark_completed(self) -> None:
+        self.update_status(ServerStatus.COMPLETED)
+
+    def mark_failed(self) -> None:
+        self.update_status(ServerStatus.FAILED)
+
+    def cancel(self) -> None:
+        self.update_status(ServerStatus.CANCELED)
+
+    def update_status(self, new_status: ServerStatus) -> None:
+        self.status = new_status
+        if new_status in {ServerStatus.COMPLETED, ServerStatus.FAILED, ServerStatus.CANCELED}:
+            self.completed_at = datetime.now()
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "recipe_name": self.recipe_name,
+            "status": self.status.value,
+            "command": self.command,
+            "ports": list(self.ports),
+            "orchestrator_handle": self.orchestrator_handle,
+            "created_at": self.created_at.isoformat(),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }
+
+    def get_metrics(self) -> Dict[str, Any]:
+        return {
+            "instance_id": self.id,
+            "recipe_name": self.recipe_name,
+            "status": self.status.value,
+            "uptime_seconds": self._uptime_seconds(),
+            "ports": list(self.ports),
+            **self.metadata,
+        }
+
+    # ------------------------------------------------------------------
+    def _uptime_seconds(self) -> float:
+        end_time = self.completed_at or datetime.now()
+        return (end_time - self.created_at).total_seconds()
+
+
+__all__ = ["ServerInstance", "ServerStatus"]


### PR DESCRIPTION
## Summary
- add a server package with CLI entry point, manager, orchestrator, recipe loader, and runtime instance model
- provide an example server recipe and placeholder workspace to demonstrate configuration structure
- document the new server commands in the README and expose a shim for `python -m server`

## Testing
- python -m server --help
- python -m server list
- python -m server info --recipe example-server
- python -m server status